### PR TITLE
Add missing function : SplunkTracingBase\Client\ClientSpan\addTags()

### DIFF
--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -95,6 +95,12 @@ class ClientSpan implements \SplunkTracingBase\Span {
         return $this;
     }
 
+    public function setTags($tags){
+      foreach ($tags as $key => $value){
+        $this->_tags[$key] = $value;
+      }
+    }
+
     public function setBaggageItem($key, $value) {
         $this->_baggage[$key] = $value;
         return $this;


### PR DESCRIPTION
Called from :
lib/Client/ClientTracer.php:213:                $span->setTags($fields['tags']);